### PR TITLE
Fix memory leak

### DIFF
--- a/dist/FileProcessor.js
+++ b/dist/FileProcessor.js
@@ -123,7 +123,7 @@ var FileProcessor = function () {
                             }
 
                             (0, _debug2.default)('File process complete');
-                            return _context3.abrupt('return');
+                            return _context3.abrupt('return', true);
 
                           case 3:
                             if (!_this2.paused) {
@@ -150,12 +150,14 @@ var FileProcessor = function () {
                             shouldContinue = _context3.sent;
 
                             if (!(shouldContinue !== false)) {
-                              _context3.next = 18;
+                              _context3.next = 17;
                               break;
                             }
 
-                            _context3.next = 18;
-                            return processIndex(index + 1);
+                            return _context3.abrupt('return', processIndex(index + 1));
+
+                          case 17:
+                            return _context3.abrupt('return', false);
 
                           case 18:
                           case 'end':

--- a/src/FileProcessor.js
+++ b/src/FileProcessor.js
@@ -61,13 +61,7 @@ class FileProcessor {
         return processIndex(index + 1);
       }
       return false;
-    }
-
-    const waitForUnpause = () => {
-      return new Promise((resolve) => {
-        this.unpauseHandlers.push(resolve);
-      })
-    }
+    };
 
     await processIndex(startIndex);
   }

--- a/src/FileProcessor.js
+++ b/src/FileProcessor.js
@@ -45,7 +45,7 @@ class FileProcessor {
     const processIndex = async index => {
       if (index === totalChunks || index === endIndex) {
         debug('File process complete');
-        return;
+        return true;
       }
       if (this.paused) {
         await this.waitForUnpause();
@@ -58,9 +58,16 @@ class FileProcessor {
 
       const shouldContinue = await fn(checksum, index, chunk);
       if (shouldContinue !== false) {
-        await processIndex(index + 1);
+        return processIndex(index + 1);
       }
-    };
+      return false;
+    }
+
+    const waitForUnpause = () => {
+      return new Promise((resolve) => {
+        this.unpauseHandlers.push(resolve);
+      })
+    }
 
     await processIndex(startIndex);
   }


### PR DESCRIPTION
PR to merge the fix to master, so we can use the simpler package reference in console and discovery.

Alternatively, clients could use the upstream 1.0.2 version which was just released with the fix.
https://github.com/QubitProducts/gcs-browser-upload/commits/master

and npm release:
https://www.npmjs.com/package/gcs-browser-upload/v/1.0.2
